### PR TITLE
Fix/removes attempt to have multiple lms connections, outside of viewer

### DIFF
--- a/external-logger.js
+++ b/external-logger.js
@@ -1,5 +1,3 @@
-import LocalMessaging from "./local-messaging";
-
 let displaySettings = {};
 let companySettings = {};
 
@@ -19,8 +17,6 @@ export default class ExternalLogger {
 
     if (!message){
       error = "Message is required";
-    } else if (!message.from) {
-      error = "From is required";
     } else if (!message.data.projectName) {
       error = "BQ project name is required";
     } else if (!message.data.datasetName) {
@@ -42,11 +38,10 @@ export default class ExternalLogger {
     const displayId = displaySettings.displayid || displaySettings.tempdisplayid || detail.display_id || "preview";
     const companyId = companySettings.companyid || companySettings.tempcompanyid || detail.company_id || "";
 
-    const data = Object.assign({}, {"event": evt, "display_id": displayId, "company_id": companyId}, detail);
+    const data = Object.assign({}, {"event": evt, "display_id": displayId, "company_id": companyId, "component_name": this.componentName}, detail);
 
     return {
         "topic": "log",
-        "from": this.componentName,
         "data": {
           "projectName": this.projectName,
           "datasetName": this.datasetName,
@@ -65,7 +60,6 @@ export default class ExternalLogger {
     const errorMessage = this._validateMessage(message, detail);
 
     if (!errorMessage && this.localMessaging.canConnect()) {
-      console.log(message);
       this.localMessaging.broadcastMessage(message);
     } else {
       console.log(`external-logger error - ${this.componentName + " component" || "source component undefined"}: ${errorMessage}`);

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 import LocalMessaging from "./local-messaging";
+import ExternalLogger from "./external-logger";
 
 export {
-  LocalMessaging
+  LocalMessaging,
+  ExternalLogger
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "common-component",
-  "version": "1.5.6",
+  "version": "1.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1702,31 +1702,6 @@
         "asynckit": "0.4.0",
         "combined-stream": "1.0.5",
         "mime-types": "2.1.17"
-      }
-    },
-    "fs-extra": {
-      "version": "git+https://github.com/Rise-Vision/node-fs-extra.git#11f233e7ed20e6057bcbaf797734b6ab5988871c",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "git+https://github.com/Rise-Vision/node-graceful-fs.git#849cab0189f4ff1ea85281695f2650c02cc63041",
-        "jsonfile": "2.4.0",
-        "klaw": "1.3.1",
-        "path-is-absolute": "1.0.1",
-        "rimraf": "git+https://github.com/Rise-Vision/rimraf.git#bbd756f17794e7d8e59a92500a2a7e835d43630d"
-      },
-      "dependencies": {
-        "graceful-fs": {
-          "version": "git+https://github.com/Rise-Vision/node-graceful-fs.git#849cab0189f4ff1ea85281695f2650c02cc63041",
-          "dev": true
-        },
-        "rimraf": {
-          "version": "git+https://github.com/Rise-Vision/rimraf.git#bbd756f17794e7d8e59a92500a2a7e835d43630d",
-          "dev": true,
-          "requires": {
-            "glob": "7.1.2",
-            "graceful-fs": "git+https://github.com/Rise-Vision/node-graceful-fs.git#849cab0189f4ff1ea85281695f2650c02cc63041"
-          }
-        }
       }
     },
     "fs.realpath": {
@@ -5465,6 +5440,31 @@
             "semver": "5.0.3"
           }
         },
+        "fs-extra": {
+          "version": "git+https://github.com/Rise-Vision/node-fs-extra.git#11f233e7ed20e6057bcbaf797734b6ab5988871c",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "git+https://github.com/Rise-Vision/node-graceful-fs.git#849cab0189f4ff1ea85281695f2650c02cc63041",
+            "jsonfile": "2.4.0",
+            "klaw": "1.3.1",
+            "path-is-absolute": "1.0.1",
+            "rimraf": "git+https://github.com/Rise-Vision/rimraf.git#bbd756f17794e7d8e59a92500a2a7e835d43630d"
+          },
+          "dependencies": {
+            "rimraf": {
+              "version": "git+https://github.com/Rise-Vision/rimraf.git#bbd756f17794e7d8e59a92500a2a7e835d43630d",
+              "dev": true,
+              "requires": {
+                "glob": "7.1.2",
+                "graceful-fs": "git+https://github.com/Rise-Vision/node-graceful-fs.git#849cab0189f4ff1ea85281695f2650c02cc63041"
+              }
+            }
+          }
+        },
+        "graceful-fs": {
+          "version": "git+https://github.com/Rise-Vision/node-graceful-fs.git#849cab0189f4ff1ea85281695f2650c02cc63041",
+          "dev": true
+        },
         "https-proxy-agent": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
@@ -5480,6 +5480,10 @@
           "version": "5.0.3",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
           "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no=",
+          "dev": true
+        },
+        "windows-shortcuts": {
+          "version": "git://github.com/Rise-Vision/windows-shortcuts.git#32fee96f6bdeeddb1cf4a9d87a0adf883b70587b",
           "dev": true
         }
       }
@@ -6123,10 +6127,6 @@
       "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
       "dev": true,
       "optional": true
-    },
-    "windows-shortcuts": {
-      "version": "git://github.com/Rise-Vision/windows-shortcuts.git#32fee96f6bdeeddb1cf4a9d87a0adf883b70587b",
-      "dev": true
     },
     "wordwrap": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "common-component",
-  "version": "1.5.6",
+  "version": "1.6.0",
   "description": "Common code for new rise components",
   "main": "index.js",
   "scripts": {

--- a/test/unit/external-logger.test.js
+++ b/test/unit/external-logger.test.js
@@ -80,13 +80,13 @@ describe("ExternalLogger", () => {
     it("should send message to LM and log to BQ", () => {
       let expectedMessage = {
         topic: 'log',
-        from: 'component-name',
         data: {
           'projectName': 'project-name',
           'datasetName': 'dataset-name',
           'failedEntryFile': 'failed-entryfile',
           'table': 'table',
           'data': {
+            'component_name': 'component-name',
             'event': 'event',
             "detail": "testDetail",
             "display_id": "preview",


### PR DESCRIPTION
As per [LMS](https://github.com/Rise-Vision/local-messaging-module/blob/master/src/local-messaging.js#L33-L35) the problem was that we were trying to overwrite the `from`, which caused the connection to drop. 

- `from` will always be viewer for any LMS messages.
- Created a custom property `component_name`, which we'll have to add to all messages
- We'll have to handle identification through this new property instead of `from`