### PR TITLE
Add feature for watching single files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "common-component",
-  "version": "1.8.0",
+  "version": "1.11.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "common-component",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "Common code for new rise components",
   "main": "index.js",
   "scripts": {

--- a/player-local-storage.js
+++ b/player-local-storage.js
@@ -93,7 +93,7 @@ export default class PlayerLocalStorage {
   }
 
   _handleLicensingUpdate(message) {
-    if (message && message.userFriendlyStatus) {
+    if (message && typeof message.hasOwnProperty("isAuthorized")) {
       this._clearLicensingRequestTimer();
 
       const previousAuthorized = this.authorized;
@@ -104,7 +104,7 @@ export default class PlayerLocalStorage {
         this.authorized = message.isAuthorized;
 
         this._sendEvent({
-          "event": message.userFriendlyStatus
+          "event": message.isAuthorized ? "authorized": "unauthorized",
         });
       }
     } else {

--- a/player-local-storage.js
+++ b/player-local-storage.js
@@ -93,7 +93,7 @@ export default class PlayerLocalStorage {
   }
 
   _handleLicensingUpdate(message) {
-    if (message && typeof message.hasOwnProperty("isAuthorized")) {
+    if (message && message.hasOwnProperty("isAuthorized")) {
       this._clearLicensingRequestTimer();
 
       const previousAuthorized = this.authorized;

--- a/player-local-storage.js
+++ b/player-local-storage.js
@@ -115,7 +115,7 @@ export default class PlayerLocalStorage {
   _handleFileUpdate(message) {
     if ( !message || !message.filePath || !message.status ) {return;}
 
-    const {filePath, status, ospath} = message;
+    const {filePath, status, osurl} = message;
     const watchedFileStatus = this.files.get(filePath);
 
     // file is not being watched
@@ -127,7 +127,7 @@ export default class PlayerLocalStorage {
 
     switch (status.toUpperCase()) {
       case "CURRENT":
-        this._sendEvent({"event": "file-available", filePath, "fileUrl": ospath.startsWith("http") ? ospath : `file://${ospath}`});
+        this._sendEvent({"event": "file-available", filePath, "fileUrl": osurl});
         break;
       case "STALE":
         this._sendEvent({"event": "file-processing", filePath});

--- a/player-local-storage.js
+++ b/player-local-storage.js
@@ -101,7 +101,7 @@ export default class PlayerLocalStorage {
 
     switch (status.toUpperCase()) {
       case "CURRENT":
-        this._sendEvent({"event": "file-available", filePath, "fileUrl": `file://${ospath}`});
+        this._sendEvent({"event": "file-available", filePath, "fileUrl": ospath.startsWith("http") ? ospath : `file://${ospath}`});
         break;
       case "STALE":
         this._sendEvent({"event": "file-processing", filePath});

--- a/test/unit/player-local-storage.test.js
+++ b/test/unit/player-local-storage.test.js
@@ -242,15 +242,16 @@ describe("PlayerLocalStorage", () => {
           "topic": "file-update",
           "filePath": "test.png",
           "status": "current",
-          "ospath": "rvplayer/modules/local-storage/xxxx/cache/ABC123"
+          "ospath": "rvplayer/modules/local-storage/xxxx/cache/ABC123",
+          "osurl": "file:///rvplayer/modules/local-storage/xxxx/cache/ABC123"
         };
 
         playerLocalStorage.watchFiles("test.png");
         playerLocalStorage._handleMessage(message);
         expect(eventHandler).toHaveBeenCalledWith({
           event: "file-available",
-          filePath: "test.png",
-          fileUrl: "file://rvplayer/modules/local-storage/xxxx/cache/ABC123"
+          filePath: message.filePath,
+          fileUrl: message.osurl
         });
       });
 
@@ -260,7 +261,8 @@ describe("PlayerLocalStorage", () => {
           "topic": "file-update",
           "filePath": "test.png",
           "status": "current",
-          "ospath": "rvplayer/modules/local-storage/xxxx/cache/ABC123"
+          "ospath": "rvplayer/modules/local-storage/xxxx/cache/ABC123",
+          "osurl": "rvplayer/modules/local-storage/xxxx/cache/ABC123"
         };
 
         playerLocalStorage.watchFiles("test.png");
@@ -271,28 +273,6 @@ describe("PlayerLocalStorage", () => {
 
         playerLocalStorage._handleMessage(message);
         expect(eventHandler).toHaveBeenCalledTimes(0);
-      });
-
-      it("should not apply file:// to fileUrl if http exists in ospath", () => {
-        const message = {
-          "from": "storage-module",
-          "topic": "file-update",
-          "filePath": "test.png",
-          "status": "stale"
-        };
-
-        playerLocalStorage.watchFiles("test.png");
-        playerLocalStorage._handleMessage(message);
-
-        message.status = "CURRENT";
-        message.ospath = "http://localhost:8080/cache/ABC123";
-
-        playerLocalStorage._handleMessage(message);
-        expect(eventHandler).toHaveBeenCalledWith({
-          event: "file-available",
-          filePath: "test.png",
-          fileUrl: "http://localhost:8080/cache/ABC123"
-        });
       });
 
       it("should execute 'file-processing' event on event handler when status is STALE", () => {

--- a/test/unit/player-local-storage.test.js
+++ b/test/unit/player-local-storage.test.js
@@ -241,6 +241,28 @@ describe("PlayerLocalStorage", () => {
         expect(eventHandler).toHaveBeenCalledTimes(0);
       });
 
+      it("should not apply file:// to fileUrl if http exists in ospath", () => {
+        const message = {
+          "from": "storage-module",
+          "topic": "file-update",
+          "filePath": "test.png",
+          "status": "stale"
+        };
+
+        playerLocalStorage.watchFiles("test.png");
+        playerLocalStorage._handleMessage(message);
+
+        message.status = "CURRENT";
+        message.ospath = "http://localhost:8080/cache/ABC123";
+
+        playerLocalStorage._handleMessage(message);
+        expect(eventHandler).toHaveBeenCalledWith({
+          event: "file-available",
+          filePath: "test.png",
+          fileUrl: "http://localhost:8080/cache/ABC123"
+        });
+      });
+
       it("should execute 'file-processing' event on event handler when status is STALE", () => {
         const message = {
           "from": "storage-module",

--- a/test/unit/player-local-storage.test.js
+++ b/test/unit/player-local-storage.test.js
@@ -134,9 +134,288 @@ describe("PlayerLocalStorage", () => {
           "event": "authorized"
         });
       });
+
+      it("should not update authorization or execute event on handler if authorization hasn't changed", () => {
+        const message = {
+          "from": "storage-module",
+          "topic": "storage-licensing-update",
+          "isAuthorized": true,
+          "userFriendlyStatus": "authorized"
+        };
+
+        expect(playerLocalStorage.isAuthorized()).toBeNull();
+
+        playerLocalStorage._handleMessage(message);
+
+        expect(playerLocalStorage.isAuthorized()).toBeTruthy();
+        expect(eventHandler).toHaveBeenCalledTimes(1);
+
+        playerLocalStorage._handleMessage(message);
+        expect(playerLocalStorage.isAuthorized()).toBeTruthy();
+        expect(eventHandler).toHaveBeenCalledTimes(1);
+
+      });
     });
 
-    it("should not update authorization or execute event on handler if authorization hasn't changed", () => {
+    describe("FILE-UPDATE", () => {
+      beforeEach(()=>{
+        const message = {
+          "from": "storage-module",
+          "topic": "storage-licensing-update",
+          "isAuthorized": true,
+          "userFriendlyStatus": "authorized"
+        };
+
+        playerLocalStorage._handleMessage(message);
+        eventHandler.mockClear();
+      });
+
+      it("should not execute if 'message' does not contain required props", () => {
+        const message = {
+          "from": "storage-module",
+          "topic": "file-update"
+        };
+
+        playerLocalStorage._handleMessage(message);
+        expect(eventHandler).toHaveBeenCalledTimes(0);
+
+        message.filePath = "test.png";
+
+        playerLocalStorage._handleMessage(message);
+        expect(eventHandler).toHaveBeenCalledTimes(0);
+
+        message.status = "noexist";
+
+        playerLocalStorage.watchFiles("test.png");
+        playerLocalStorage._handleMessage(message);
+        expect(eventHandler).toHaveBeenCalledTimes(1);
+
+      });
+
+      it("should not execute if message pertains to a file not being watched", () => {
+        const message = {
+          "from": "storage-module",
+          "topic": "file-update",
+          "filePath": "non-watched-file.png",
+          "status": "stale"
+        };
+
+        playerLocalStorage._handleMessage(message);
+        expect(eventHandler).toHaveBeenCalledTimes(0);
+      });
+
+      it("should execute 'file-available' event on event handler when message status is CURRENT", () => {
+        const message = {
+          "from": "storage-module",
+          "topic": "file-update",
+          "filePath": "test.png",
+          "status": "current",
+          "ospath": "rvplayer/modules/local-storage/xxxx/cache/ABC123"
+        };
+
+        playerLocalStorage.watchFiles("test.png");
+        playerLocalStorage._handleMessage(message);
+        expect(eventHandler).toHaveBeenCalledWith({
+          event: "file-available",
+          filePath: "test.png",
+          fileUrl: "file://rvplayer/modules/local-storage/xxxx/cache/ABC123"
+        });
+      });
+
+      it("should not execute any event on event handler when watched file status is same as new status", () => {
+        const message = {
+          "from": "storage-module",
+          "topic": "file-update",
+          "filePath": "test.png",
+          "status": "current",
+          "ospath": "rvplayer/modules/local-storage/xxxx/cache/ABC123"
+        };
+
+        playerLocalStorage.watchFiles("test.png");
+        playerLocalStorage._handleMessage(message);
+        expect(eventHandler).toHaveBeenCalledTimes(1);
+
+        eventHandler.mockClear();
+
+        playerLocalStorage._handleMessage(message);
+        expect(eventHandler).toHaveBeenCalledTimes(0);
+      });
+
+      it("should execute 'file-processing' event on event handler when status is STALE", () => {
+        const message = {
+          "from": "storage-module",
+          "topic": "file-update",
+          "filePath": "test.png",
+          "status": "stale"
+        };
+
+        playerLocalStorage.watchFiles("test.png");
+        playerLocalStorage._handleMessage(message);
+        expect(eventHandler).toHaveBeenCalledWith({
+          event: "file-processing",
+          filePath: "test.png"
+        });
+      });
+
+      it("should execute 'storage-file-no-exist' event on event handler when status is NOEXIST", () => {
+        const message = {
+          "from": "storage-module",
+          "topic": "file-update",
+          "filePath": "test.png",
+          "status": "noexist"
+        };
+
+        playerLocalStorage.watchFiles("test.png");
+        playerLocalStorage._handleMessage(message);
+        expect(eventHandler).toHaveBeenCalledWith({
+          event: "file-no-exist",
+          filePath: "test.png"
+        });
+      });
+
+      it("should execute 'storage-file-deleted' event on event handler when status is DELETED", () => {
+        const message = {
+          "from": "storage-module",
+          "topic": "file-update",
+          "filePath": "test.png",
+          "status": "deleted"
+        };
+
+        playerLocalStorage.watchFiles("test.png");
+        playerLocalStorage._handleMessage(message);
+        expect(eventHandler).toHaveBeenCalledWith({
+          event: "file-deleted",
+          filePath: "test.png"
+        });
+      });
+    });
+
+    describe("FILE-ERROR", () => {
+      beforeEach(()=>{
+        const message = {
+          "from": "storage-module",
+          "topic": "storage-licensing-update",
+          "isAuthorized": true,
+          "userFriendlyStatus": "authorized"
+        };
+
+        playerLocalStorage._handleMessage(message);
+        eventHandler.mockClear();
+      });
+
+      it("should not execute if 'message' does not contain filePath prop", () => {
+        const message = {
+          "from": "storage-module",
+          "topic": "file-error"
+        };
+
+        playerLocalStorage._handleMessage(message);
+        expect(eventHandler).toHaveBeenCalledTimes(0);
+      });
+
+      it("should not execute if message pertains to a file not being watched", () => {
+        const message = {
+          "from": "storage-module",
+          "topic": "file-error",
+          "filePath": "non-watched-file.png",
+          "msg": "Insufficient disk space"
+        };
+
+        playerLocalStorage.watchFiles("test.png");
+        playerLocalStorage._handleMessage(message);
+        expect(eventHandler).toHaveBeenCalledTimes(0);
+      });
+
+      it("should execute 'storage-file-error' event on event handler", () => {
+        const message = {
+          "from": "storage-module",
+          "topic": "file-error",
+          "filePath": "test.png",
+          "msg": "Could not retrieve signed URL",
+          "detail": "Some response details"
+        };
+
+        playerLocalStorage.watchFiles("test.png");
+        playerLocalStorage._handleMessage(message);
+        expect(eventHandler).toHaveBeenCalledWith({
+          event: "file-error",
+          filePath: message.filePath,
+          msg: message.msg,
+          detail: message.detail
+        });
+      });
+    });
+  });
+
+  describe("_watchFile", () => {
+    beforeEach(()=>{
+      localMessaging = new LocalMessaging();
+      playerLocalStorage = new PlayerLocalStorage(localMessaging, eventHandler);
+
+      const message = {
+        "from": "storage-module",
+        "topic": "storage-licensing-update",
+        "isAuthorized": true,
+        "userFriendlyStatus": "authorized"
+      };
+      playerLocalStorage._handleMessage(message);
+    });
+
+    it("should broadcast WATCH of single file", () => {
+      playerLocalStorage._watchFile("test.png");
+
+      expect(top.RiseVision.Viewer.LocalMessaging.write).toHaveBeenCalledWith({
+        "topic": "WATCH",
+        "filePath": "test.png"
+      });
+    });
+  });
+
+  describe("watchFiles()", () => {
+
+    it("should not execute if not connected", () => {
+      mockViewerLocalMessaging(false);
+      localMessaging = new LocalMessaging();
+      playerLocalStorage = new PlayerLocalStorage(localMessaging, eventHandler);
+
+      const spy = jest.spyOn(playerLocalStorage, '_watchFile');
+
+      playerLocalStorage.watchFiles(["test1.png", "test2.png"]);
+
+      expect(spy).toHaveBeenCalledTimes(0);
+
+      spy.mockReset();
+      spy.mockRestore();
+    });
+
+    it("should not execute if not authorized", () => {
+      mockViewerLocalMessaging(true);
+      localMessaging = new LocalMessaging();
+      playerLocalStorage = new PlayerLocalStorage(localMessaging, eventHandler);
+
+      const message = {
+        "from": "storage-module",
+        "topic": "storage-licensing-update",
+        "isAuthorized": false,
+        "userFriendlyStatus": "unauthorized"
+      };
+
+      const spy = jest.spyOn(playerLocalStorage, '_watchFile');
+
+      playerLocalStorage._handleMessage(message);
+
+      playerLocalStorage.watchFiles(["test1.png", "test2.png"]);
+
+      expect(spy).toHaveBeenCalledTimes(0);
+
+      spy.mockReset();
+      spy.mockRestore();
+    });
+
+    it("should watch one single file provided as a param string", () => {
+      localMessaging = new LocalMessaging();
+      playerLocalStorage = new PlayerLocalStorage(localMessaging, eventHandler);
+
       const message = {
         "from": "storage-module",
         "topic": "storage-licensing-update",
@@ -144,19 +423,39 @@ describe("PlayerLocalStorage", () => {
         "userFriendlyStatus": "authorized"
       };
 
-      expect(playerLocalStorage.isAuthorized()).toBeNull();
+      const spy = jest.spyOn(playerLocalStorage, '_watchFile');
 
       playerLocalStorage._handleMessage(message);
+      playerLocalStorage.watchFiles("test.png");
 
-      expect(playerLocalStorage.isAuthorized()).toBeTruthy();
-      expect(eventHandler).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith("test.png");
 
-      playerLocalStorage._handleMessage(message);
-      expect(playerLocalStorage.isAuthorized()).toBeTruthy();
-      expect(eventHandler).toHaveBeenCalledTimes(1);
-
+      spy.mockReset();
+      spy.mockRestore();
     });
 
+    it("should start watching multiple single files", () => {
+      const spy = jest.spyOn(playerLocalStorage, '_watchFile');
+
+      playerLocalStorage.watchFiles(["test1.png", "test2.png"]);
+
+      expect(spy).toHaveBeenCalledTimes(2);
+
+      spy.mockReset();
+      spy.mockRestore();
+    });
+
+    it("should only send watch of single files that aren't already being watched", () => {
+      const spy = jest.spyOn(playerLocalStorage, '_watchFile');
+
+      playerLocalStorage.watchFiles(["test.png", "test1.png", "test2.png", "test3.png"]);
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith("test3.png");
+
+      spy.mockReset();
+      spy.mockRestore();
+    });
   });
 
 });


### PR DESCRIPTION
- `watchFiles()`, can provide a single file to watch or an Array of files
- broadcasts WATCH of file(s) and handles FILE-UPDATE and FILE-ERROR messages from Local Storage module
- on FILE-UPDATE messages, handles all applicable statuses - CURRENT, STALE, NOEXIST, and DELETED and executes events on event handlers for each:
  - `file-available`: provides `filePath` and `fileUrl`
  - `file-processing`
  - `file-no-exist`
  - `file-deleted`
- on FILE-ERROR messages, handles and executes event on event handlers: 
  - `file-error`: provides `filePath`, `msg`, and `detail`
- example use can be seen in Image Widget PR - https://github.com/Rise-Vision/widget-image/pull/142