### PR TITLE
Adding feature of watching a folder of files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "common-component",
-  "version": "1.11.4",
+  "version": "1.12.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "common-component",
-  "version": "1.11.4",
+  "version": "1.12.0",
   "description": "Common code for new rise components",
   "main": "index.js",
   "scripts": {

--- a/player-local-storage.js
+++ b/player-local-storage.js
@@ -98,7 +98,7 @@ export default class PlayerLocalStorage {
     if ( !message || !message.filePath || !message.status ) {return;}
 
     const {filePath, status, osurl} = message;
-    const watchedFileStatus = this.files.get(filePath);
+    const watchedFileStatus = this._getWatchedFileStatus(filePath);
 
     // file is not being watched
     if (!watchedFileStatus) {return;}
@@ -157,6 +157,23 @@ export default class PlayerLocalStorage {
 
   _isFolderPath(path) {
     return path.substring(path.length - 1) === "/";
+  }
+
+  _getWatchedFileStatus(filePath) {
+    let fileStatus = this.files.get(filePath);
+
+    if (!fileStatus) {
+      for (let folderPath of this.folders) {
+        if (filePath.includes(folderPath)) {
+          // this is a file from a watched folder, add to file list and mark its status UNKNOWN
+          this.files.set(filePath, "UNKNOWN");
+          fileStatus = "UNKNOWN";
+          break;
+        }
+      }
+    }
+
+    return fileStatus;
   }
 
   /*

--- a/player-local-storage.js
+++ b/player-local-storage.js
@@ -175,7 +175,7 @@ export default class PlayerLocalStorage {
 
     if (!fileStatus) {
       for (let folderPath of this.folders) {
-        if (filePath.includes(folderPath)) {
+        if (filePath.startsWith(folderPath)) {
           // this is a file from a watched folder, add to file list and mark its status UNKNOWN
           this.files.set(filePath, "UNKNOWN");
           fileStatus = "UNKNOWN";
@@ -206,7 +206,7 @@ export default class PlayerLocalStorage {
     }
 
     for (let extension of extensions) {
-      if ((filePath.toLowerCase()).includes(extension)) {
+      if ((filePath.toLowerCase()).endsWith(extension)) {
         isValid = true;
         break;
       }

--- a/test/unit/player-local-storage.test.js
+++ b/test/unit/player-local-storage.test.js
@@ -274,6 +274,35 @@ describe("PlayerLocalStorage", () => {
         });
       });
 
+      it("should execute event on handler when message pertains to file not being watched but is from a watched folder", () => {
+        const message = {
+          "from": "storage-module",
+          "topic": "file-update",
+          "filePath": "test-bucket/test-folder/watched-folder-test-file.png",
+          "status": "stale"
+        };
+
+        playerLocalStorage.watchFiles("test-bucket/test-folder/");
+        playerLocalStorage._handleMessage(message);
+        expect(eventHandler).toHaveBeenCalledWith({
+          event: "file-processing",
+          filePath: "test-bucket/test-folder/watched-folder-test-file.png"
+        });
+      });
+
+      it("should not execute event on handler when message pertains to file not being watched and is not from a watched folder", () => {
+        const message = {
+          "from": "storage-module",
+          "topic": "file-update",
+          "filePath": "test-bucket/test-folder-2/unwatched-folder-test-file.png",
+          "status": "stale"
+        };
+
+        playerLocalStorage.watchFiles("test-bucket/test-folder/");
+        playerLocalStorage._handleMessage(message);
+        expect(eventHandler).toHaveBeenCalledTimes(0);
+      });
+
       it("should execute 'storage-file-no-exist' event on event handler when status is NOEXIST", () => {
         const message = {
           "from": "storage-module",

--- a/test/unit/player-local-storage.test.js
+++ b/test/unit/player-local-storage.test.js
@@ -550,6 +550,7 @@ describe("PlayerLocalStorage", () => {
     it("should return false for an invalid image file", () => {
       playerLocalStorage._setFileType("image");
 
+      expect(playerLocalStorage._isValidFileType("test-bucket/test-file.jpg.webm")).toBeFalsy();
       expect(playerLocalStorage._isValidFileType("test-bucket/test-file.webm")).toBeFalsy();
       expect(playerLocalStorage._isValidFileType("test-bucket/test-file.mp4")).toBeFalsy();
       expect(playerLocalStorage._isValidFileType("test-bucket/test-file.ogv")).toBeFalsy();
@@ -562,6 +563,7 @@ describe("PlayerLocalStorage", () => {
     it("should return false for an invalid video file", () => {
       playerLocalStorage._setFileType("video");
 
+      expect(playerLocalStorage._isValidFileType("test-bucket/test-file.webm.jpg")).toBeFalsy();
       expect(playerLocalStorage._isValidFileType("test-bucket/test-file.jpg")).toBeFalsy();
       expect(playerLocalStorage._isValidFileType("test-bucket/test-file.jpeg")).toBeFalsy();
       expect(playerLocalStorage._isValidFileType("test-bucket/test-file.png")).toBeFalsy();


### PR DESCRIPTION
- Can now provide a folder path to `watchFiles()` and it will facilitate events to consumer for all files from that folder
- `watchFiles()` maintains flexibility in providing it a single String (file or folder) or an Array of file paths or folder paths (or both). 
- Adding optional param `filterByFileType` to `watchFiles()` function for enabling to filter by file type. Acceptable file types are _"image"_ and _"video"_. 
  - When providing a file type in a `watchFiles()` call, if there are any file paths provided in that call that aren't of the file type specified, they do not get watched at all. 
  - If there are any files from a watched folder that aren't of the file type specified, the consumer is not notified of any events associated with that file.