### PR TITLE
Update file status when handling file error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "common-component",
-  "version": "1.12.2",
+  "version": "1.12.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "common-component",
-  "version": "1.12.2",
+  "version": "1.12.3",
   "description": "Common code for new rise components",
   "main": "index.js",
   "scripts": {

--- a/player-local-storage.js
+++ b/player-local-storage.js
@@ -146,6 +146,8 @@ export default class PlayerLocalStorage {
     // file is not of assigned filter type, don't notify listener
     if(!this._isValidFileType(filePath)) {return;}
 
+    this.files.set(filePath, "file-error");
+
     this._sendEvent({"event": "file-error", filePath, msg, detail});
   }
 

--- a/test/unit/player-local-storage.test.js
+++ b/test/unit/player-local-storage.test.js
@@ -444,6 +444,7 @@ describe("PlayerLocalStorage", () => {
 
         playerLocalStorage.watchFiles("test.png");
         playerLocalStorage._handleMessage(message);
+        expect(playerLocalStorage._getWatchedFileStatus("test.png")).toBe("file-error");
         expect(eventHandler).toHaveBeenCalledWith({
           event: "file-error",
           filePath: message.filePath,


### PR DESCRIPTION
- Ensure the files status is changed on FILE-ERROR handling so that a subsequent FILE-UPDATE message (ie. STALE) isn't the same when previous vs new status comparison is made