### PR TITLE
Adding initial abstraction of licensing for player-local-storage

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 import LocalMessaging from "./local-messaging";
 import ExternalLogger from "./external-logger";
 import PlayerLocalStorage from "./player-local-storage";
+import PlayerLocalStorageLicensing from "./player-local-storage-licensing";
 import Config from './config/config';
 import EventHandler from './event-handler';
 import Logger from './logger';
@@ -9,6 +10,7 @@ export {
   LocalMessaging,
   ExternalLogger,
   PlayerLocalStorage,
+  PlayerLocalStorageLicensing,
   Config,
   EventHandler,
   Logger

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "common-component",
-  "version": "1.12.3",
+  "version": "1.13.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "common-component",
-  "version": "1.12.3",
+  "version": "1.13.0",
   "description": "Common code for new rise components",
   "main": "index.js",
   "scripts": {

--- a/player-local-storage-licensing.js
+++ b/player-local-storage-licensing.js
@@ -1,0 +1,93 @@
+export default class PlayerLocalStorageLicensing {
+  constructor(localMessaging, eventsHandler, companyId = "") {
+    this.localMessaging = localMessaging;
+    this.eventsHandler = eventsHandler;
+    this.companyId = companyId;
+    this.authorized = null;
+  }
+
+  _bindReceiveMessagesHandler() {
+    this.localMessaging.receiveMessages((message) => { this._handleMessage(message) });
+  }
+
+  _sendLicensingRequest() {
+    this.localMessaging.broadcastMessage({topic: "storage-licensing-request"});
+  }
+
+  _handleMessage(message) {
+    if (!message || !message.topic) {return;}
+
+    switch (message.topic.toUpperCase()) {
+      case "STORAGE-LICENSING-UPDATE":
+        return this._handleLicensingUpdate(message);
+    }
+  }
+
+  _handleLicensingUpdate(message) {
+    if (message && message.hasOwnProperty("isAuthorized")) {
+      const previousAuthorized = this.authorized;
+      const currentAuthorized = message.isAuthorized;
+
+      // detect licensing change
+      if (previousAuthorized !== currentAuthorized) {
+        this.authorized = message.isAuthorized;
+
+        this._sendEvent({
+          "event": message.isAuthorized ? "authorized": "unauthorized",
+        });
+      }
+    } else {
+      console.log(`Error: Invalid STORAGE-LICENSING-UPDATE message - ${message}`);
+    }
+  }
+
+  _sendEvent(event) {
+    if (!this.eventsHandler || typeof this.eventsHandler !== "function" || !event) {return;}
+    this.eventsHandler(event);
+  }
+
+
+  _isCompanyWhiteListed(companyId) {
+    if (!companyId || typeof companyId !== "string") {return false;}
+
+    // "Rise Vision Inc":  f114ad26-949d-44b4-87e9-8528afc76ce4
+    // "*DO NOT DELETE* Rise Vision Templates": 7fa5ee92-7deb-450b-a8d5-e5ed648c575f
+
+    const whiteList = ["f114ad26-949d-44b4-87e9-8528afc76ce4", "7fa5ee92-7deb-450b-a8d5-e5ed648c575f"];
+
+    return whiteList.includes(companyId);
+  }
+
+  /*
+  PUBLIC API
+   */
+
+  requestAuthorization() {
+    // no company id, get authorization from licensing module
+    if (!this.companyId || typeof this.companyId !== "string") {
+      if (this.authorized !== null) {
+        // already know status, send it
+        this._sendEvent({"event": this.authorized ? "authorized": "unauthorized"});
+      } else {
+        // listen for licensing messages
+        this._bindReceiveMessagesHandler();
+        // request licensing authorization from Licensing module
+        this._sendLicensingRequest();
+      }
+
+      return;
+    }
+
+    // company is white listed, consider it authorized
+    if (this._isCompanyWhiteListed(this.companyId)) {
+      this.authorized = true;
+      return this._sendEvent({"event": "authorized"});
+    }
+
+    //TODO: check session storage
+  }
+
+  isAuthorized() {
+    return this.authorized;
+  }
+}

--- a/test/unit/player-local-storage-licensing.test.js
+++ b/test/unit/player-local-storage-licensing.test.js
@@ -1,0 +1,197 @@
+import LocalMessaging from "../../local-messaging";
+import PlayerLocalStorageLicensing from "../../player-local-storage-licensing";
+
+describe("PlayerLocalStorageLicensing", () => {
+  let playerLocalStorageLicensing = null;
+  let localMessaging = null;
+  let eventHandler = null;
+
+  function mockViewerLocalMessaging(connected) {
+    top.RiseVision = {};
+    top.RiseVision.Viewer = {};
+    top.RiseVision.Viewer.LocalMessaging = {
+      canConnect: () => {return connected;}
+    };
+
+    top.RiseVision.Viewer.LocalMessaging.write = jest.genMockFn();
+    top.RiseVision.Viewer.LocalMessaging.receiveMessages = jest.genMockFn();
+  }
+
+  beforeEach(() => {
+    mockViewerLocalMessaging(true);
+    eventHandler = jest.genMockFn();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("_handleMessage()", () => {
+
+    beforeEach(() => {
+      jest.useFakeTimers();
+      localMessaging = new LocalMessaging();
+      playerLocalStorageLicensing = new PlayerLocalStorageLicensing(localMessaging, eventHandler);
+    });
+
+    afterEach(() => {
+      jest.clearAllTimers();
+    });
+
+    describe("STORAGE-LICENSING-UPDATE", () => {
+      beforeEach(()=>{
+        eventHandler.mockClear();
+      });
+
+      it("should update authorization and execute 'licensing' event on event handler", () => {
+        const message = {
+          "from": "storage-module",
+          "topic": "storage-licensing-update",
+          "isAuthorized": false,
+          "userFriendlyStatus": "unauthorized"
+        };
+
+        playerLocalStorageLicensing._handleMessage(message);
+
+        expect(playerLocalStorageLicensing.isAuthorized()).toBeFalsy();
+        expect(eventHandler).toHaveBeenCalledWith({
+          "event": "unauthorized"
+        });
+
+        message.isAuthorized = true;
+        message.userFriendlyStatus = "authorized";
+        eventHandler.mockClear();
+
+        playerLocalStorageLicensing._handleMessage(message);
+
+        expect(playerLocalStorageLicensing.isAuthorized()).toBeTruthy();
+        expect(eventHandler).toHaveBeenCalledWith({
+          "event": "authorized"
+        });
+      });
+
+      it("should not update authorization or execute event on handler if authorization hasn't changed", () => {
+        const message = {
+          "from": "storage-module",
+          "topic": "storage-licensing-update",
+          "isAuthorized": true,
+          "userFriendlyStatus": "authorized"
+        };
+
+        expect(playerLocalStorageLicensing.isAuthorized()).toBeNull();
+
+        playerLocalStorageLicensing._handleMessage(message);
+
+        expect(playerLocalStorageLicensing.isAuthorized()).toBeTruthy();
+        expect(eventHandler).toHaveBeenCalledTimes(1);
+
+        playerLocalStorageLicensing._handleMessage(message);
+        expect(playerLocalStorageLicensing.isAuthorized()).toBeTruthy();
+        expect(eventHandler).toHaveBeenCalledTimes(1);
+
+      });
+    });
+
+  });
+
+  describe("_isCompanyWhiteListed", () => {
+    beforeEach(() => {
+      localMessaging = new LocalMessaging();
+      playerLocalStorageLicensing = new PlayerLocalStorageLicensing(localMessaging, eventHandler);
+    });
+
+    it("should return false when company id is empty or not a string", () => {
+      expect(playerLocalStorageLicensing._isCompanyWhiteListed()).toBeFalsy();
+      expect(playerLocalStorageLicensing._isCompanyWhiteListed(["test"])).toBeFalsy();
+
+    });
+
+    it("should return true when company id is in whitelist", () => {
+      expect(playerLocalStorageLicensing._isCompanyWhiteListed("f114ad26-949d-44b4-87e9-8528afc76ce4")).toBeTruthy();
+      expect(playerLocalStorageLicensing._isCompanyWhiteListed("7fa5ee92-7deb-450b-a8d5-e5ed648c575f")).toBeTruthy();
+
+    });
+
+    it("should return false when company id is not in whitelist", () => {
+      expect(playerLocalStorageLicensing._isCompanyWhiteListed("abc-123")).toBeFalsy();
+    });
+
+  });
+
+  describe("requestAuthorization", () => {
+
+    describe("no company id provided", () => {
+
+      beforeEach(()=>{
+        localMessaging = new LocalMessaging();
+        playerLocalStorageLicensing = new PlayerLocalStorageLicensing(localMessaging, eventHandler);
+      });
+
+      afterEach(() => {
+        eventHandler.mockClear();
+      });
+
+      it("should send licensing request and listen for messages", () => {
+        playerLocalStorageLicensing.requestAuthorization();
+
+        expect(top.RiseVision.Viewer.LocalMessaging.write).toHaveBeenCalledWith({
+          "topic": "storage-licensing-request"
+        });
+
+      });
+
+      it("should execute event on handler providing status and not send licensing request when status already available", () => {
+        const message = {
+          "from": "storage-module",
+          "topic": "storage-licensing-update",
+          "isAuthorized": true,
+          "userFriendlyStatus": "authorized"
+        };
+
+
+        playerLocalStorageLicensing._handleMessage(message);
+        playerLocalStorageLicensing.requestAuthorization();
+        expect(top.RiseVision.Viewer.LocalMessaging.write).toHaveBeenCalledTimes(0);
+
+        expect(playerLocalStorageLicensing.isAuthorized()).toBeTruthy();
+        expect(eventHandler).toHaveBeenCalledWith({
+          "event": "authorized"
+        });
+
+      });
+    });
+
+    describe("company is white listed", () => {
+      afterEach(() => {
+        eventHandler.mockClear();
+      });
+
+      it("should execute event on handler providing authorized status with f114ad26-949d-44b4-87e9-8528afc76ce4", () => {
+        localMessaging = new LocalMessaging();
+        playerLocalStorageLicensing = new PlayerLocalStorageLicensing(localMessaging, eventHandler, "f114ad26-949d-44b4-87e9-8528afc76ce4");
+        playerLocalStorageLicensing.requestAuthorization();
+
+        expect(top.RiseVision.Viewer.LocalMessaging.write).toHaveBeenCalledTimes(0);
+        expect(playerLocalStorageLicensing.isAuthorized()).toBeTruthy();
+        expect(eventHandler).toHaveBeenCalledWith({
+          "event": "authorized"
+        });
+      });
+
+      it("should execute event on handler providing authorized status with 7fa5ee92-7deb-450b-a8d5-e5ed648c575f", () => {
+        localMessaging = new LocalMessaging();
+        playerLocalStorageLicensing = new PlayerLocalStorageLicensing(localMessaging, eventHandler, "7fa5ee92-7deb-450b-a8d5-e5ed648c575f");
+        playerLocalStorageLicensing.requestAuthorization();
+
+        expect(top.RiseVision.Viewer.LocalMessaging.write).toHaveBeenCalledTimes(0);
+        expect(playerLocalStorageLicensing.isAuthorized()).toBeTruthy();
+        expect(eventHandler).toHaveBeenCalledWith({
+          "event": "authorized"
+        });
+      });
+    });
+
+  });
+
+
+});

--- a/test/unit/player-local-storage.test.js
+++ b/test/unit/player-local-storage.test.js
@@ -3,6 +3,7 @@ import PlayerLocalStorage from "../../player-local-storage";
 
 describe("PlayerLocalStorage", () => {
   let playerLocalStorage = null;
+  let playerLocalStorageLicensing = null;
   let localMessaging = null;
   let eventHandler = null;
 
@@ -17,8 +18,16 @@ describe("PlayerLocalStorage", () => {
     top.RiseVision.Viewer.LocalMessaging.receiveMessages = jest.genMockFn();
   }
 
+  function mockLicensing(authorized) {
+    playerLocalStorageLicensing = {
+      requestAuthorization:jest.genMockFn(),
+      isAuthorized:()=>{return authorized;}
+    };
+  }
+
   beforeEach(() => {
     mockViewerLocalMessaging(true);
+    mockLicensing(true);
     eventHandler = jest.genMockFn();
   });
 
@@ -31,7 +40,7 @@ describe("PlayerLocalStorage", () => {
       mockViewerLocalMessaging(false);
 
       localMessaging = new LocalMessaging();
-      playerLocalStorage = new PlayerLocalStorage(localMessaging, eventHandler);
+      playerLocalStorage = new PlayerLocalStorage(localMessaging, playerLocalStorageLicensing, eventHandler);
 
       expect(eventHandler).toHaveBeenCalledWith({
         "event": "no-connection"
@@ -42,7 +51,7 @@ describe("PlayerLocalStorage", () => {
       mockViewerLocalMessaging(true);
 
       localMessaging = new LocalMessaging();
-      playerLocalStorage = new PlayerLocalStorage(localMessaging, eventHandler);
+      playerLocalStorage = new PlayerLocalStorage(localMessaging, playerLocalStorageLicensing, eventHandler);
 
       expect(eventHandler).toHaveBeenCalledTimes(0);
       expect(top.RiseVision.Viewer.LocalMessaging.write).toHaveBeenCalledWith({
@@ -56,7 +65,7 @@ describe("PlayerLocalStorage", () => {
     beforeEach(() => {
       jest.useFakeTimers();
       localMessaging = new LocalMessaging();
-      playerLocalStorage = new PlayerLocalStorage(localMessaging, eventHandler);
+      playerLocalStorage = new PlayerLocalStorage(localMessaging, playerLocalStorageLicensing, eventHandler);
     });
 
     afterEach(() => {
@@ -64,7 +73,7 @@ describe("PlayerLocalStorage", () => {
     });
 
     describe("CLIENT-LIST", () => {
-      it("should send STORAGE-LICENSING-REQUEST  when required modules are present", () => {
+      it("should make licensing instance request authorization when required modules are present", () => {
         const message = {
           "topic": "client-list",
           "clients": ["local-messaging", "player-electron", "local-storage", "licensing", "logger"]
@@ -73,12 +82,10 @@ describe("PlayerLocalStorage", () => {
         top.RiseVision.Viewer.LocalMessaging.write.mockClear();
         playerLocalStorage._handleMessage(message);
 
-        expect(top.RiseVision.Viewer.LocalMessaging.write).toHaveBeenCalledWith({
-          "topic": "storage-licensing-request"
-        });
+        expect(playerLocalStorageLicensing.requestAuthorization).toHaveBeenCalledTimes(1);
       });
 
-      it("should not send STORAGE-LICENSING-REQUEST when receiving message again and modules are available", () => {
+      it("should not make licensing instance request authorization when receiving message again and modules are available", () => {
         const message = {
           "topic": "client-list",
           "clients": ["local-messaging", "player-electron", "local-storage", "licensing", "logger"]
@@ -89,7 +96,7 @@ describe("PlayerLocalStorage", () => {
         playerLocalStorage._handleMessage(message);
         playerLocalStorage._handleMessage(message);
 
-        expect(top.RiseVision.Viewer.LocalMessaging.write).toHaveBeenCalledTimes(1);
+        expect(playerLocalStorageLicensing.requestAuthorization).toHaveBeenCalledTimes(1);
       });
 
       it("should send CLIENT-LIST-REQUEST 30 more times every 1 second before executing required-modules-unavailable event on event handler", () => {
@@ -118,70 +125,8 @@ describe("PlayerLocalStorage", () => {
       });
     });
 
-    describe("STORAGE-LICENSING-UPDATE", () => {
-      beforeEach(()=>{
-        eventHandler.mockClear();
-      });
-
-      it("should update authorization and execute 'licensing' event on event handler", () => {
-        const message = {
-          "from": "storage-module",
-          "topic": "storage-licensing-update",
-          "isAuthorized": false,
-          "userFriendlyStatus": "unauthorized"
-        };
-
-        playerLocalStorage._handleMessage(message);
-
-        expect(playerLocalStorage.isAuthorized()).toBeFalsy();
-        expect(eventHandler).toHaveBeenCalledWith({
-          "event": "unauthorized"
-        });
-
-        message.isAuthorized = true;
-        message.userFriendlyStatus = "authorized";
-        eventHandler.mockClear();
-
-        playerLocalStorage._handleMessage(message);
-
-        expect(playerLocalStorage.isAuthorized()).toBeTruthy();
-        expect(eventHandler).toHaveBeenCalledWith({
-          "event": "authorized"
-        });
-      });
-
-      it("should not update authorization or execute event on handler if authorization hasn't changed", () => {
-        const message = {
-          "from": "storage-module",
-          "topic": "storage-licensing-update",
-          "isAuthorized": true,
-          "userFriendlyStatus": "authorized"
-        };
-
-        expect(playerLocalStorage.isAuthorized()).toBeNull();
-
-        playerLocalStorage._handleMessage(message);
-
-        expect(playerLocalStorage.isAuthorized()).toBeTruthy();
-        expect(eventHandler).toHaveBeenCalledTimes(1);
-
-        playerLocalStorage._handleMessage(message);
-        expect(playerLocalStorage.isAuthorized()).toBeTruthy();
-        expect(eventHandler).toHaveBeenCalledTimes(1);
-
-      });
-    });
-
     describe("FILE-UPDATE", () => {
       beforeEach(()=>{
-        const message = {
-          "from": "storage-module",
-          "topic": "storage-licensing-update",
-          "isAuthorized": true,
-          "userFriendlyStatus": "authorized"
-        };
-
-        playerLocalStorage._handleMessage(message);
         eventHandler.mockClear();
       });
 
@@ -524,7 +469,7 @@ describe("PlayerLocalStorage", () => {
   describe("_isFolderPath()", () => {
     beforeEach(()=>{
       localMessaging = new LocalMessaging();
-      playerLocalStorage = new PlayerLocalStorage(localMessaging, eventHandler);
+      playerLocalStorage = new PlayerLocalStorage(localMessaging, playerLocalStorageLicensing, eventHandler);
 
       const message = {
         "from": "storage-module",
@@ -548,7 +493,7 @@ describe("PlayerLocalStorage", () => {
   describe("_isValidFileType()", () => {
     beforeEach(()=>{
       localMessaging = new LocalMessaging();
-      playerLocalStorage = new PlayerLocalStorage(localMessaging, eventHandler);
+      playerLocalStorage = new PlayerLocalStorage(localMessaging, playerLocalStorageLicensing, eventHandler);
 
       const message = {
         "from": "storage-module",
@@ -623,7 +568,7 @@ describe("PlayerLocalStorage", () => {
   describe("_watchFile()", () => {
     beforeEach(()=>{
       localMessaging = new LocalMessaging();
-      playerLocalStorage = new PlayerLocalStorage(localMessaging, eventHandler);
+      playerLocalStorage = new PlayerLocalStorage(localMessaging, playerLocalStorageLicensing, eventHandler);
 
       const message = {
         "from": "storage-module",
@@ -647,7 +592,7 @@ describe("PlayerLocalStorage", () => {
   describe("_watchFolder()", () => {
     beforeEach(()=>{
       localMessaging = new LocalMessaging();
-      playerLocalStorage = new PlayerLocalStorage(localMessaging, eventHandler);
+      playerLocalStorage = new PlayerLocalStorage(localMessaging, playerLocalStorageLicensing, eventHandler);
 
       const message = {
         "from": "storage-module",
@@ -671,9 +616,10 @@ describe("PlayerLocalStorage", () => {
   describe("watchFiles()", () => {
 
     it("should not execute if filePaths params is falsy", () => {
-      mockViewerLocalMessaging(false);
+      mockViewerLocalMessaging(true);
+      mockLicensing(true);
       localMessaging = new LocalMessaging();
-      playerLocalStorage = new PlayerLocalStorage(localMessaging, eventHandler);
+      playerLocalStorage = new PlayerLocalStorage(localMessaging, playerLocalStorageLicensing, eventHandler);
 
       const spyFile = jest.spyOn(playerLocalStorage, '_watchFile');
       const spyFolder = jest.spyOn(playerLocalStorage, '_watchFolder');
@@ -691,8 +637,9 @@ describe("PlayerLocalStorage", () => {
 
     it("should not execute if not connected", () => {
       mockViewerLocalMessaging(false);
+      mockLicensing(true);
       localMessaging = new LocalMessaging();
-      playerLocalStorage = new PlayerLocalStorage(localMessaging, eventHandler);
+      playerLocalStorage = new PlayerLocalStorage(localMessaging, playerLocalStorageLicensing, eventHandler);
 
       const spy = jest.spyOn(playerLocalStorage, '_watchFile');
 
@@ -706,8 +653,9 @@ describe("PlayerLocalStorage", () => {
 
     it("should not execute if not authorized", () => {
       mockViewerLocalMessaging(true);
+      mockLicensing(false);
       localMessaging = new LocalMessaging();
-      playerLocalStorage = new PlayerLocalStorage(localMessaging, eventHandler);
+      playerLocalStorage = new PlayerLocalStorage(localMessaging, playerLocalStorageLicensing, eventHandler);
 
       const message = {
         "from": "storage-module",
@@ -730,7 +678,7 @@ describe("PlayerLocalStorage", () => {
 
     it("should watch one single file provided as a param string", () => {
       localMessaging = new LocalMessaging();
-      playerLocalStorage = new PlayerLocalStorage(localMessaging, eventHandler);
+      playerLocalStorage = new PlayerLocalStorage(localMessaging, playerLocalStorageLicensing, eventHandler);
 
       const message = {
         "from": "storage-module",


### PR DESCRIPTION
- Adding `player-local-storage-licensing` to abstract all licensing functionality
- Widgets will instantiate licensing instance separately and provide it as a constructor param to `player-local-storage` instance. This is to adhere to Babel transpiling in Widgets
- A company id is optional for licensing instance and company whitelist functionality has been added
- Additional functionality regarding directly requesting from store api and use of browser session storage will be coming in follow up PRs