### PR TITLE
Support watching files via Content Sentinel

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "common-component",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "description": "Common code for new rise components",
   "main": "index.js",
   "scripts": {

--- a/rise-content-sentinel.js
+++ b/rise-content-sentinel.js
@@ -10,7 +10,7 @@ export default class RiseContentSentinel {
   }
 
   _bindReceiveMessagesHandler() {
-    window.addEventListener( "message", this._receiveData, false );
+    window.addEventListener( "message", event => this._receiveData( event ) );
   }
 
   _receiveData( event ) {

--- a/rise-content-sentinel.js
+++ b/rise-content-sentinel.js
@@ -5,28 +5,12 @@ export default class RiseContentSentinel {
     this.folders = new Set();
     this.fileTypes = ["image", "video"];
     this.fileType = "";
-    this.embeddedPresentations = [];
 
     this._bindReceiveMessagesHandler();
   }
 
   _bindReceiveMessagesHandler() {
     window.addEventListener( "message", this._receiveData, false );
-  }
-
-  _isAncestor( source ) {
-    const checkParent = parent => source === parent ||
-      ( parent.parent && parent !== parent.parent && checkParent( parent.parent ));
-
-    return window.parent && checkParent( window.parent );
-  }
-
-  _handleEmbeddedFileWatch( source, message ) {
-    if ( !this.embeddedPresentations.includes( source )) {
-      this.embeddedPresentations.push( source )
-    }
-
-    this._send( message );
   }
 
   _receiveData( event ) {
@@ -36,30 +20,10 @@ export default class RiseContentSentinel {
       return;
     }
 
-    const topic = message.topic.toUpperCase();
-
-    if ( topic === "WATCH" && !this._isAncestor( event.source )) {
-      this._handleEmbeddedFileWatch( event.source, message );
-    } else if ( topic === "FILE-UPDATE" || topic === "FILE-ERROR" ) {
-      this._handleFileResponse( message );
-    }
+    this._handleMessage( message );
   }
 
-  _handleFileResponse(message) {
-    this._handleMessage(message);
-
-    this.embeddedPresentations.forEach( source => {
-      try {
-        source.postMessage( message, "*" );
-      } catch ( error ) {
-        console.warn( error );
-      }
-    });
-  }
-
-  _handleMessage(message) {
-    if (!message || !message.topic) {return;}
-
+  _handleMessage( message ) {
     switch (message.topic.toUpperCase()) {
       case "FILE-UPDATE":
         return this._handleFileUpdate( message );

--- a/rise-content-sentinel.js
+++ b/rise-content-sentinel.js
@@ -151,20 +151,35 @@ export default class RiseContentSentinel {
     }
   }
 
+  _getViewerWindow() {
+    let win = window;
+
+    while (win.parent && win.parent !== win) {
+      win = win.parent;
+
+      if ( win.RiseVision && win.RiseVision.Viewer ) {
+        break;
+      }
+    }
+
+    return win;
+  }
+
   _send(message) {
+    if (!message) {return;}
+
+    if ( window.parent === window ) {return;}
+
     const frameElementId = this._getHttpParameter( "frameElementId" ) ?
       this._getHttpParameter( "frameElementId" ) :
       window.frameElement ? window.frameElement.id : "";
 
-    message = message || {};
+    const viewerWindow = this._getViewerWindow();
+
     message.topic = "watch";
     message.frameElementId = frameElementId;
 
-    if ( window.parent === window ) {
-      return;
-    }
-
-    window.parent.postMessage( message, "*" );
+    viewerWindow && viewerWindow.postMessage( message, "*" );
   }
 
   _getWatchedFileStatus(filePath) {

--- a/rise-content-sentinel.js
+++ b/rise-content-sentinel.js
@@ -1,0 +1,283 @@
+export default class RiseContentSentinel {
+  constructor(eventsHandler) {
+    this.eventsHandler = eventsHandler;
+    this.files = new Map();
+    this.folders = new Set();
+    this.fileTypes = ["image", "video"];
+    this.fileType = "";
+    this.embeddedPresentations = [];
+
+    this._bindReceiveMessagesHandler();
+  }
+
+  _bindReceiveMessagesHandler() {
+    window.addEventListener( "message", this._receiveData, false );
+  }
+
+  _isAncestor( source ) {
+    const checkParent = parent => source === parent ||
+      ( parent.parent && parent !== parent.parent && checkParent( parent.parent ));
+
+    return window.parent && checkParent( window.parent );
+  }
+
+  _handleEmbeddedFileWatch( source, message ) {
+    if ( !this.embeddedPresentations.includes( source )) {
+      this.embeddedPresentations.push( source )
+    }
+
+    this._send( message );
+  }
+
+  _receiveData( event ) {
+    const message = event.data;
+
+    if ( !message || !message.topic ) {
+      return;
+    }
+
+    const topic = message.topic.toUpperCase();
+
+    if ( topic === "WATCH" && !this._isAncestor( event.source )) {
+      this._handleEmbeddedFileWatch( event.source, message );
+    } else if ( topic === "FILE-UPDATE" || topic === "FILE-ERROR" ) {
+      this._handleFileResponse( message );
+    }
+  }
+
+  _handleFileResponse(message) {
+    this._handleMessage(message);
+
+    this.embeddedPresentations.forEach( source => {
+      try {
+        source.postMessage( message, "*" );
+      } catch ( error ) {
+        console.warn( error );
+      }
+    });
+  }
+
+  _handleMessage(message) {
+    if (!message || !message.topic) {return;}
+
+    switch (message.topic.toUpperCase()) {
+      case "FILE-UPDATE":
+        return this._handleFileUpdate( message );
+      case "FILE-ERROR":
+        return this._handleFileError( message );
+    }
+  }
+
+  _handleFileUpdate(message) {
+    if ( !message || !message.filePath || !message.status ) {return;}
+
+    const {filePath, status} = message;
+    const origin = "https://widgets.risevision.com";
+    const fileUrl = `${origin}/${filePath}`;
+    const watchedFileStatus = this._getWatchedFileStatus(filePath);
+    const isFolderPath = this._isFolderPath(filePath);
+
+    // file is not being watched
+    if (!watchedFileStatus) {return;}
+    // status hasn't changed
+    if (watchedFileStatus === status) {return;}
+
+    this.files.set(filePath, status);
+
+    // file is not of assigned filter type, don't notify listener
+    if(!isFolderPath && !this._isValidFileType(filePath)) {return;}
+
+    switch (status.toUpperCase()) {
+      case "CURRENT":
+        this._sendEvent({"event": "file-available", filePath, fileUrl});
+        break;
+      case "STALE":
+        this._sendEvent({"event": "file-processing", filePath});
+        break;
+      case "NOEXIST":
+        if (isFolderPath) {
+          this._sendEvent({"event": "folder-no-exist", filePath});
+        } else {
+          this._sendEvent({"event": "file-no-exist", filePath});
+        }
+        break;
+      case "EMPTYFOLDER":
+        this._sendEvent({"event": "folder-empty", filePath});
+        break;
+      case "DELETED":
+        this._sendEvent({"event": "file-deleted", filePath});
+        break;
+    }
+  }
+
+  _handleFileError(message) {
+    if (!message || !message.filePath) {return;}
+
+    const {filePath, msg, detail} = message;
+    const watchedFileStatus = this._getWatchedFileStatus(filePath);
+
+    // file is not being watched
+    if (!watchedFileStatus) {return;}
+    // file is not of assigned filter type, don't notify listener
+    if(!this._isValidFileType(filePath)) {return;}
+
+    this.files.set(filePath, "file-error");
+
+    this._sendEvent({"event": "file-error", filePath, msg, detail});
+  }
+
+  _sendEvent(event) {
+    if (!this.eventsHandler || typeof this.eventsHandler !== "function" || !event) {return;}
+    this.eventsHandler(event);
+  }
+
+  _setFileType(type) {
+    // reset file type
+    if (type === "") {
+      this.fileType = "";
+      return;
+    }
+
+    // type is not recognized
+    if (!type || !this.fileTypes.includes(type)) {return;}
+
+    this.fileType = type;
+  }
+
+  _isFolderPath(path) {
+    return path.substring(path.length - 1) === "/";
+  }
+
+  _watchFolder(folderPath) {
+    this.folders.add(folderPath);
+
+    this._send({
+      from: "content-consumer",
+      to: "content-sentinel-controller",
+      msg: "watch",
+      filePath: folderPath
+    });
+  }
+
+  _watchFile(filePath) {
+    // file is not of assigned filter type, don't watch the file at all
+    if(!this._isValidFileType(filePath)) {return;}
+
+    this.files.set(filePath, "UNKNOWN");
+
+    this._send({
+      from: "content-consumer",
+      to: "content-sentinel-controller",
+      msg: "watch",
+      filePath
+    });
+  }
+
+  _getHttpParameter( name ) {
+    try {
+      const href = window.location.href;
+      const regex = new RegExp( `[?&]${ name }=([^&#]*)`, "i" );
+      const match = regex.exec( href );
+
+      return match ? match[ 1 ] : null;
+    } catch ( err ) {
+      console.log( "can't retrieve HTTP parameter", err );
+
+      return null;
+    }
+  }
+
+  _send(message) {
+    const frameElementId = this._getHttpParameter( "frameElementId" ) ?
+      this._getHttpParameter( "frameElementId" ) :
+      window.frameElement ? window.frameElement.id : "";
+
+    message = message || {};
+    message.topic = "watch";
+    message.frameElementId = frameElementId;
+
+    if ( window.parent === window ) {
+      return;
+    }
+
+    window.parent.postMessage( message, "*" );
+  }
+
+  _getWatchedFileStatus(filePath) {
+    let fileStatus = this.files.get(filePath);
+
+    if (!fileStatus) {
+      for (let folderPath of this.folders) {
+        if (filePath.startsWith(folderPath)) {
+          // this is a file from a watched folder, add to file list and mark its status UNKNOWN
+          this.files.set(filePath, "UNKNOWN");
+          fileStatus = "UNKNOWN";
+          break;
+        }
+      }
+    }
+
+    return fileStatus;
+  }
+
+  _isValidFileType(filePath) {
+    let isValid = false;
+    let extensions;
+
+    // no filter set, accept any type
+    if (!this.fileType) {return true;}
+
+    switch(this.fileType) {
+      case "image":
+        extensions = [".jpg", ".jpeg", ".png", ".bmp", ".svg", ".gif", ".webp"];
+        break;
+      case "video":
+        extensions = [".webm", ".mp4"];
+        break;
+      default:
+        extensions = [];
+    }
+
+    for (let extension of extensions) {
+      if ((filePath.toLowerCase()).endsWith(extension)) {
+        isValid = true;
+        break;
+      }
+    }
+
+    return isValid;
+  }
+
+  /*
+  PUBLIC API
+   */
+
+  watchFiles(filePaths, filterByFileType = "") {
+    if (!filePaths) {return;}
+
+    this._setFileType(filterByFileType);
+
+    if (typeof filePaths === "string") {
+      if (this._isFolderPath(filePaths)) {
+        if (!this.folders.has(filePaths)) {
+          this._watchFolder(filePaths);
+        }
+      } else {
+        if (!this.files.has(filePaths)) {
+          this._watchFile(filePaths);
+        }
+      }
+    } else if (Array.isArray(filePaths)) {
+      const filesNotWatched = filePaths.filter(path => !this.files.has(path));
+      filesNotWatched.forEach((path) => {
+        if (this._isFolderPath(path)) {
+          if (!this.folders.has(path)) {
+            this._watchFolder(path);
+          }
+        } else {
+          this._watchFile(path);
+        }
+      });
+    }
+  }
+}

--- a/test/unit/rise-content-sentinel.test.js
+++ b/test/unit/rise-content-sentinel.test.js
@@ -33,7 +33,6 @@ describe("RiseContentSentinel", () => {
 
       it("should not execute if 'message' does not contain required props", () => {
         const message = {
-          "from": "storage-module",
           "topic": "file-update"
         };
 
@@ -55,7 +54,6 @@ describe("RiseContentSentinel", () => {
 
       it("should not execute if message pertains to a file not being watched", () => {
         const message = {
-          "from": "storage-module",
           "topic": "file-update",
           "filePath": "non-watched-file.png",
           "status": "stale"

--- a/test/unit/rise-content-sentinel.test.js
+++ b/test/unit/rise-content-sentinel.test.js
@@ -1,0 +1,557 @@
+import RiseContentSentinel from "../../rise-content-sentinel";
+import LocalMessaging from "../../local-messaging";
+import PlayerLocalStorage from "../../player-local-storage";
+
+describe("RiseContentSentinel", () => {
+  const origin = "https://widgets.risevision.com";
+
+  let riseContentSentinel = null;
+  let eventHandler = null;
+
+  beforeEach(() => {
+    eventHandler = jest.genMockFn();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("_handleMessage()", () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+      riseContentSentinel = new RiseContentSentinel(eventHandler);
+    });
+
+    afterEach(() => {
+      jest.clearAllTimers();
+    });
+
+    describe("FILE-UPDATE", () => {
+      beforeEach(()=>{
+        eventHandler.mockClear();
+      });
+
+      it("should not execute if 'message' does not contain required props", () => {
+        const message = {
+          "from": "storage-module",
+          "topic": "file-update"
+        };
+
+        riseContentSentinel._handleMessage(message);
+        expect(eventHandler).toHaveBeenCalledTimes(0);
+
+        message.filePath = "test.png";
+
+        riseContentSentinel._handleMessage(message);
+        expect(eventHandler).toHaveBeenCalledTimes(0);
+
+        message.status = "noexist";
+
+        riseContentSentinel.watchFiles("test.png");
+        riseContentSentinel._handleMessage(message);
+        expect(eventHandler).toHaveBeenCalledTimes(1);
+
+      });
+
+      it("should not execute if message pertains to a file not being watched", () => {
+        const message = {
+          "from": "storage-module",
+          "topic": "file-update",
+          "filePath": "non-watched-file.png",
+          "status": "stale"
+        };
+
+        riseContentSentinel._handleMessage(message);
+        expect(eventHandler).toHaveBeenCalledTimes(0);
+      });
+
+      it("should execute 'file-available' event on event handler when message status is CURRENT", () => {
+        const message = {
+          "topic": "file-update",
+          "filePath": "test.png",
+          "status": "current"
+        };
+
+        riseContentSentinel.watchFiles("test.png");
+        riseContentSentinel._handleMessage(message);
+        expect(eventHandler).toHaveBeenCalledWith({
+          event: "file-available",
+          filePath: message.filePath,
+          fileUrl: `${origin}/${message.filePath}`
+        });
+      });
+
+      it("should not execute any event on event handler when watched file status is same as new status", () => {
+        const message = {
+          "topic": "file-update",
+          "filePath": "test.png",
+          "status": "current"
+        };
+
+        riseContentSentinel.watchFiles("test.png");
+        riseContentSentinel._handleMessage(message);
+        expect(eventHandler).toHaveBeenCalledTimes(1);
+
+        eventHandler.mockClear();
+
+        riseContentSentinel._handleMessage(message);
+        expect(eventHandler).toHaveBeenCalledTimes(0);
+      });
+
+      it("should execute 'file-processing' event on event handler when status is STALE", () => {
+        const message = {
+          "topic": "file-update",
+          "filePath": "test.png",
+          "status": "stale"
+        };
+
+        riseContentSentinel.watchFiles("test.png");
+        riseContentSentinel._handleMessage(message);
+        expect(eventHandler).toHaveBeenCalledWith({
+          event: "file-processing",
+          filePath: "test.png"
+        });
+      });
+
+      it("should execute event on handler when message pertains to file not being watched but is from a watched folder", () => {
+        const message = {
+          "topic": "file-update",
+          "filePath": "test-bucket/test-folder/watched-folder-test-file.png",
+          "status": "stale"
+        };
+
+        riseContentSentinel.watchFiles("test-bucket/test-folder/");
+        riseContentSentinel._handleMessage(message);
+        expect(eventHandler).toHaveBeenCalledWith({
+          event: "file-processing",
+          filePath: "test-bucket/test-folder/watched-folder-test-file.png"
+        });
+      });
+
+      it("should execute event on handler when message pertains to file being watched and is valid file type", () => {
+        const message = {
+          "topic": "file-update",
+          "filePath": "test-bucket/test-folder/test-image-file.png",
+          "status": "stale"
+        };
+
+        riseContentSentinel.watchFiles("test-bucket/test-folder/", "image");
+        riseContentSentinel._handleMessage(message);
+        expect(eventHandler).toHaveBeenCalledWith({
+          event: "file-processing",
+          filePath: "test-bucket/test-folder/test-image-file.png"
+        });
+      });
+
+      it("should not execute event on handler when message pertains to file not being watched and is not from a watched folder", () => {
+        const message = {
+          "topic": "file-update",
+          "filePath": "test-bucket/test-folder-2/unwatched-folder-test-file.png",
+          "status": "stale"
+        };
+
+        riseContentSentinel.watchFiles("test-bucket/test-folder/");
+        riseContentSentinel._handleMessage(message);
+        expect(eventHandler).toHaveBeenCalledTimes(0);
+      });
+
+      it("should not execute event on handler when message pertains to file being watched but is not a valid file type", () => {
+        const message = {
+          "topic": "file-update",
+          "filePath": "test-bucket/test-folder/test-image-file.png",
+          "status": "stale"
+        };
+
+        riseContentSentinel.watchFiles("test-bucket/test-folder/", "video");
+        riseContentSentinel._handleMessage(message);
+        expect(eventHandler).toHaveBeenCalledTimes(0);
+      });
+
+      it("should execute 'file-no-exist' event on event handler when status is NOEXIST", () => {
+        const message = {
+          "topic": "file-update",
+          "filePath": "test.png",
+          "status": "noexist"
+        };
+
+        riseContentSentinel.watchFiles("test.png");
+        riseContentSentinel._handleMessage(message);
+        expect(eventHandler).toHaveBeenCalledWith({
+          event: "file-no-exist",
+          filePath: "test.png"
+        });
+      });
+
+      it("should execute 'folder-no-exist' event on event handler when status is NOEXIST and is a watched folder", () => {
+        const message = {
+          "topic": "file-update",
+          "filePath": "test-bucket/test-folder-no-exist/",
+          "status": "noexist"
+        };
+
+        riseContentSentinel.watchFiles("test-bucket/test-folder-no-exist/", "image");
+        riseContentSentinel._handleMessage(message);
+        expect(eventHandler).toHaveBeenCalledWith({
+          event: "folder-no-exist",
+          filePath: "test-bucket/test-folder-no-exist/"
+        });
+      });
+
+      it("should execute 'folder-empty' event on event handler when status is EMPTYFOLDER and is a watched folder", () => {
+        const message = {
+          "topic": "file-update",
+          "filePath": "test-bucket/test-folder-empty/",
+          "status": "emptyfolder"
+        };
+
+        riseContentSentinel.watchFiles("test-bucket/test-folder-empty/");
+        riseContentSentinel._handleMessage(message);
+        expect(eventHandler).toHaveBeenCalledWith({
+          event: "folder-empty",
+          filePath: "test-bucket/test-folder-empty/"
+        });
+      });
+
+      it("should execute 'file-deleted' event on event handler when status is DELETED", () => {
+        const message = {
+          "topic": "file-update",
+          "filePath": "test.png",
+          "status": "deleted"
+        };
+
+        riseContentSentinel.watchFiles("test.png");
+        riseContentSentinel._handleMessage(message);
+        expect(eventHandler).toHaveBeenCalledWith({
+          event: "file-deleted",
+          filePath: "test.png"
+        });
+      });
+    });
+
+    describe("FILE-ERROR", () => {
+      beforeEach(()=>{
+        eventHandler.mockClear();
+      });
+
+      it("should not execute if 'message' does not contain filePath prop", () => {
+        const message = {
+          "topic": "file-error"
+        };
+
+        riseContentSentinel._handleMessage(message);
+        expect(eventHandler).toHaveBeenCalledTimes(0);
+      });
+
+      it("should not execute if message pertains to a file not being watched", () => {
+        const message = {
+          "topic": "file-error",
+          "filePath": "non-watched-file.png",
+          "msg": "Insufficient disk space"
+        };
+
+        riseContentSentinel.watchFiles("test.png");
+        riseContentSentinel._handleMessage(message);
+        expect(eventHandler).toHaveBeenCalledTimes(0);
+      });
+
+      it("should execute 'file-error' event on event handler", () => {
+        const message = {
+          "topic": "file-error",
+          "filePath": "test.png",
+          "msg": "Could not retrieve signed URL",
+          "detail": "Some response details"
+        };
+
+        riseContentSentinel.watchFiles("test.png");
+        riseContentSentinel._handleMessage(message);
+        expect(riseContentSentinel._getWatchedFileStatus("test.png")).toBe("file-error");
+        expect(eventHandler).toHaveBeenCalledWith({
+          event: "file-error",
+          filePath: message.filePath,
+          msg: message.msg,
+          detail: message.detail
+        });
+      });
+
+      it("should execute 'file-error' event on event handler when message pertains to file not being watched but is from a watched folder", () => {
+        const message = {
+          "topic": "file-error",
+          "filePath": "test-bucket/test-folder/watched-folder-test-file.png",
+          "msg": "Could not retrieve signed URL",
+          "detail": "Some response details"
+        };
+
+        riseContentSentinel.watchFiles("test-bucket/test-folder/");
+        riseContentSentinel._handleMessage(message);
+        expect(eventHandler).toHaveBeenCalledWith({
+          event: "file-error",
+          filePath: message.filePath,
+          msg: message.msg,
+          detail: message.detail
+        });
+      });
+
+      it("should execute 'file-error' event on event handler when message pertains to file watched and is valid file type", () => {
+        const message = {
+          "topic": "file-error",
+          "filePath": "test-bucket/test-folder/test-image-file.png",
+          "msg": "Could not retrieve signed URL",
+          "detail": "Some response details"
+        };
+
+        riseContentSentinel.watchFiles("test-bucket/test-folder/", "image");
+        riseContentSentinel._handleMessage(message);
+        expect(eventHandler).toHaveBeenCalledWith({
+          event: "file-error",
+          filePath: message.filePath,
+          msg: message.msg,
+          detail: message.detail
+        });
+      });
+
+      it("should not execute event on handler when message pertains to file not being watched and is not from a watched folder", () => {
+        const message = {
+          "topic": "file-error",
+          "filePath": "test-bucket/test-folder-2/unwatched-folder-test-file.png",
+          "msg": "Could not retrieve signed URL",
+          "detail": "Some response details"
+        };
+
+        riseContentSentinel.watchFiles("test-bucket/test-folder/");
+        riseContentSentinel._handleMessage(message);
+        expect(eventHandler).toHaveBeenCalledTimes(0);
+      });
+
+      it("should not execute event on handler when message pertains to file being watched but is not a valid file type", () => {
+        const message = {
+          "topic": "file-error",
+          "filePath": "test-bucket/test-folder/test-image-file.png",
+          "msg": "Could not retrieve signed URL",
+          "detail": "Some response details"
+        };
+
+        riseContentSentinel.watchFiles("test-bucket/test-folder/", "video");
+        riseContentSentinel._handleMessage(message);
+        expect(eventHandler).toHaveBeenCalledTimes(0);
+      });
+    });
+  });
+
+  describe("_isFolderPath()", () => {
+    beforeEach(()=>{
+      riseContentSentinel = new RiseContentSentinel(eventHandler);
+    });
+
+    it("should return true", () => {
+      expect(riseContentSentinel._isFolderPath("test-bucket/test-folder/")).toBeTruthy();
+    });
+
+    it("should return false", () => {
+      expect(riseContentSentinel._isFolderPath("test-bucket/test-file.png")).toBeFalsy();
+    });
+
+  });
+
+  describe("_isValidFileType()", () => {
+    beforeEach(()=>{
+      riseContentSentinel = new RiseContentSentinel(eventHandler);
+    });
+
+    it("should return true for a valid image file", () => {
+      riseContentSentinel._setFileType("image");
+
+      expect(riseContentSentinel._isValidFileType("test-bucket/test-file.jpg")).toBeTruthy();
+      expect(riseContentSentinel._isValidFileType("test-bucket/test-file.jpeg")).toBeTruthy();
+      expect(riseContentSentinel._isValidFileType("test-bucket/test-file.png")).toBeTruthy();
+      expect(riseContentSentinel._isValidFileType("test-bucket/test-file.bmp")).toBeTruthy();
+      expect(riseContentSentinel._isValidFileType("test-bucket/test-file.svg")).toBeTruthy();
+      expect(riseContentSentinel._isValidFileType("test-bucket/test-file.gif")).toBeTruthy();
+      expect(riseContentSentinel._isValidFileType("test-bucket/test-file.webp")).toBeTruthy();
+    });
+
+    it("should return true for a valid video file", () => {
+      riseContentSentinel._setFileType("video");
+
+      expect(riseContentSentinel._isValidFileType("test-bucket/test-file.webm")).toBeTruthy();
+      expect(riseContentSentinel._isValidFileType("test-bucket/test-file.mp4")).toBeTruthy();
+    });
+
+    it("should return false for an invalid image file", () => {
+      riseContentSentinel._setFileType("image");
+
+      expect(riseContentSentinel._isValidFileType("test-bucket/test-file.jpg.webm")).toBeFalsy();
+      expect(riseContentSentinel._isValidFileType("test-bucket/test-file.webm")).toBeFalsy();
+      expect(riseContentSentinel._isValidFileType("test-bucket/test-file.mp4")).toBeFalsy();
+      expect(riseContentSentinel._isValidFileType("test-bucket/test-file.ogv")).toBeFalsy();
+      expect(riseContentSentinel._isValidFileType("test-bucket/test-file.ogg")).toBeFalsy();
+      expect(riseContentSentinel._isValidFileType("test-bucket/test-file.html")).toBeFalsy();
+      expect(riseContentSentinel._isValidFileType("test-bucket/test-file.js")).toBeFalsy();
+      expect(riseContentSentinel._isValidFileType("test-bucket/test-file.css")).toBeFalsy();
+    });
+
+    it("should return false for an invalid video file", () => {
+      riseContentSentinel._setFileType("video");
+
+      expect(riseContentSentinel._isValidFileType("test-bucket/test-file.webm.jpg")).toBeFalsy();
+      expect(riseContentSentinel._isValidFileType("test-bucket/test-file.jpg")).toBeFalsy();
+      expect(riseContentSentinel._isValidFileType("test-bucket/test-file.jpeg")).toBeFalsy();
+      expect(riseContentSentinel._isValidFileType("test-bucket/test-file.png")).toBeFalsy();
+      expect(riseContentSentinel._isValidFileType("test-bucket/test-file.bmp")).toBeFalsy();
+      expect(riseContentSentinel._isValidFileType("test-bucket/test-file.svg")).toBeFalsy();
+      expect(riseContentSentinel._isValidFileType("test-bucket/test-file.gif")).toBeFalsy();
+      expect(riseContentSentinel._isValidFileType("test-bucket/test-file.webp")).toBeFalsy();
+      expect(riseContentSentinel._isValidFileType("test-bucket/test-file.html")).toBeFalsy();
+      expect(riseContentSentinel._isValidFileType("test-bucket/test-file.js")).toBeFalsy();
+      expect(riseContentSentinel._isValidFileType("test-bucket/test-file.css")).toBeFalsy();
+    });
+
+    it("should return true when no filter file type set", () => {
+      expect(riseContentSentinel._isValidFileType("test-bucket/test-file.jpg")).toBeTruthy();
+      expect(riseContentSentinel._isValidFileType("test-bucket/test-file.webm")).toBeTruthy();
+      expect(riseContentSentinel._isValidFileType("test-bucket/test-file.png")).toBeTruthy();
+      expect(riseContentSentinel._isValidFileType("test-bucket/test-file.mp4")).toBeTruthy();
+      expect(riseContentSentinel._isValidFileType("test-bucket/test-file.svg")).toBeTruthy();
+      expect(riseContentSentinel._isValidFileType("test-bucket/test-file.gif")).toBeTruthy();
+      expect(riseContentSentinel._isValidFileType("test-bucket/test-file.html")).toBeTruthy();
+    });
+  });
+
+  describe("_watchFile()", () => {
+    beforeEach(()=>{
+      riseContentSentinel = new RiseContentSentinel(eventHandler);
+      riseContentSentinel._send = jest.genMockFn();
+    });
+
+    it("should send WATCH of single file", () => {
+      riseContentSentinel._watchFile("test.png");
+
+      expect(riseContentSentinel._send).toHaveBeenCalledWith({
+        "filePath": "test.png",
+        "from": "content-consumer",
+        "msg": "watch",
+        "to": "content-sentinel-controller"
+      });
+    });
+  });
+
+  describe("_watchFolder()", () => {
+    beforeEach(()=>{
+      riseContentSentinel = new RiseContentSentinel(eventHandler);
+      riseContentSentinel._send = jest.genMockFn();
+    });
+
+    it("should broadcast WATCH of a folder", () => {
+      riseContentSentinel._watchFolder("test-bucket/test-folder/");
+
+      expect(riseContentSentinel._send).toHaveBeenCalledWith({
+        "from": "content-consumer",
+        "msg": "watch",
+        "to": "content-sentinel-controller",
+        "filePath": "test-bucket/test-folder/"
+      });
+    });
+  });
+
+  describe("watchFiles()", () => {
+
+    it("should not execute if filePaths params is falsy", () => {
+      riseContentSentinel = new RiseContentSentinel(eventHandler);
+
+      const spyFile = jest.spyOn(riseContentSentinel, '_watchFile');
+      const spyFolder = jest.spyOn(riseContentSentinel, '_watchFolder');
+
+      riseContentSentinel.watchFiles("");
+
+      expect(spyFile).toHaveBeenCalledTimes(0);
+      expect(spyFolder).toHaveBeenCalledTimes(0);
+
+      spyFile.mockReset();
+      spyFile.mockRestore();
+      spyFolder.mockReset();
+      spyFolder.mockRestore();
+    });
+
+    it("should watch one single file provided as a param string", () => {
+      riseContentSentinel = new RiseContentSentinel(eventHandler);
+
+      const spy = jest.spyOn(riseContentSentinel, '_watchFile');
+
+      riseContentSentinel.watchFiles("test.png");
+
+      expect(spy).toHaveBeenCalledWith("test.png");
+
+      spy.mockReset();
+      spy.mockRestore();
+    });
+
+    it("should start watching multiple single files", () => {
+      const spy = jest.spyOn(riseContentSentinel, '_watchFile');
+
+      riseContentSentinel.watchFiles(["test1.png", "test2.png"]);
+
+      expect(spy).toHaveBeenCalledTimes(2);
+
+      spy.mockReset();
+      spy.mockRestore();
+    });
+
+    it("should only send watch of single files that aren't already being watched", () => {
+      const spy = jest.spyOn(riseContentSentinel, '_watchFile');
+
+      riseContentSentinel.watchFiles(["test.png", "test1.png", "test2.png", "test3.png"]);
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith("test3.png");
+
+      spy.mockReset();
+      spy.mockRestore();
+    });
+
+    it("should watch one single folder provided as a param string", () => {
+      const spy = jest.spyOn(riseContentSentinel, '_watchFolder');
+
+      riseContentSentinel.watchFiles("test-bucket/test-folder/");
+
+      expect(spy).toHaveBeenCalledWith("test-bucket/test-folder/");
+
+      spy.mockReset();
+      spy.mockRestore();
+    });
+
+    it("should start watching multiple folders", () => {
+      const spy = jest.spyOn(riseContentSentinel, '_watchFolder');
+
+      riseContentSentinel.watchFiles(["test-bucket/test-folder-1/", "test-bucket/test-folder-2/", "test-bucket/test-folder-3/"]);
+
+      expect(spy).toHaveBeenCalledTimes(3);
+
+      spy.mockReset();
+      spy.mockRestore();
+    });
+
+    it("should only send watch of folders that aren't already being watched", () => {
+      const spy = jest.spyOn(riseContentSentinel, '_watchFolder');
+
+      riseContentSentinel.watchFiles(["test-bucket/test-folder-1/", "test-bucket/test-folder-2/", "test-bucket/test-folder-3/", "test-bucket/test-folder-4/"]);
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith("test-bucket/test-folder-4/");
+
+      spy.mockReset();
+      spy.mockRestore();
+    });
+
+    it("should call _setFileType()", () => {
+      const spy = jest.spyOn(riseContentSentinel, '_setFileType');
+
+      riseContentSentinel.watchFiles("test-bucket/test-filter-type.png", "image");
+
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith("image");
+
+      spy.mockReset();
+      spy.mockRestore();
+    });
+  });
+
+});


### PR DESCRIPTION
## Description
Added new class `RiseContentSentinel` for usage by Image and Video Widgets to watch **files** or **folders** via Content Sentinel

Watch functionality predominantly ported from `PlayerLocalStorage` class, which has been used in production by Image and Video widgets for watching files via Rise Local Storage module. 

Specific functionality for sending and receiving messages has been largely ported from common-template class [rise-viewer.js](https://github.com/Rise-Vision/common-template/blob/master/src/rise-viewer.js), particularly in regards to handling embedded presentations. 

## Motivation and Context
Image and Video Widgets caching files in Browser

## How Has This Been Tested?
Unit test coverage

Manual testing will be done once Video Widget is ready. 

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
n/a
