### PR TITLE
Add cacheKey to content sentinel file update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "common-component",
-  "version": "1.16.1",
+  "version": "1.18.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "common-component",
-  "version": "1.18.0",
+  "version": "1.18.1",
   "description": "Common code for new rise components",
   "main": "index.js",
   "scripts": {

--- a/rise-content-sentinel.js
+++ b/rise-content-sentinel.js
@@ -37,7 +37,9 @@ export default class RiseContentSentinel {
 
     const {filePath, cachePath, status} = message;
     const origin = "https://widgets.risevision.com";
-    const fileUrl = `${origin}${cachePath || "/" + filePath}`;
+    //use cachePath to form the fileUrl. Fall back to filePath for
+    //backwards compartibility with Content Sentinel v1.2.7
+    const fileUrl = `${origin}${cachePath || `/${filePath}`}`;
     const watchedFileStatus = this._getWatchedFileStatus(filePath);
     const isFolderPath = this._isFolderPath(filePath);
 

--- a/rise-content-sentinel.js
+++ b/rise-content-sentinel.js
@@ -35,9 +35,9 @@ export default class RiseContentSentinel {
   _handleFileUpdate(message) {
     if ( !message || !message.filePath || !message.status ) {return;}
 
-    const {filePath, cacheKey, status} = message;
+    const {filePath, cachePath, status} = message;
     const origin = "https://widgets.risevision.com";
-    const fileUrl = `${origin}/${cacheKey || filePath}`;
+    const fileUrl = `${origin}/${cachePath || filePath}`;
     const watchedFileStatus = this._getWatchedFileStatus(filePath);
     const isFolderPath = this._isFolderPath(filePath);
 

--- a/rise-content-sentinel.js
+++ b/rise-content-sentinel.js
@@ -35,9 +35,9 @@ export default class RiseContentSentinel {
   _handleFileUpdate(message) {
     if ( !message || !message.filePath || !message.status ) {return;}
 
-    const {filePath, status} = message;
+    const {filePath, cacheKey, status} = message;
     const origin = "https://widgets.risevision.com";
-    const fileUrl = `${origin}/${filePath}`;
+    const fileUrl = `${origin}/${cacheKey ? cacheKey : filePath}`;
     const watchedFileStatus = this._getWatchedFileStatus(filePath);
     const isFolderPath = this._isFolderPath(filePath);
 

--- a/rise-content-sentinel.js
+++ b/rise-content-sentinel.js
@@ -37,7 +37,7 @@ export default class RiseContentSentinel {
 
     const {filePath, cacheKey, status} = message;
     const origin = "https://widgets.risevision.com";
-    const fileUrl = `${origin}/${cacheKey ? cacheKey : filePath}`;
+    const fileUrl = `${origin}/${cacheKey || filePath}`;
     const watchedFileStatus = this._getWatchedFileStatus(filePath);
     const isFolderPath = this._isFolderPath(filePath);
 

--- a/rise-content-sentinel.js
+++ b/rise-content-sentinel.js
@@ -37,7 +37,7 @@ export default class RiseContentSentinel {
 
     const {filePath, cachePath, status} = message;
     const origin = "https://widgets.risevision.com";
-    const fileUrl = `${origin}/${cachePath || filePath}`;
+    const fileUrl = `${origin}${cachePath || "/" + filePath}`;
     const watchedFileStatus = this._getWatchedFileStatus(filePath);
     const isFolderPath = this._isFolderPath(filePath);
 

--- a/test/unit/rise-content-sentinel.test.js
+++ b/test/unit/rise-content-sentinel.test.js
@@ -66,11 +66,28 @@ describe("RiseContentSentinel", () => {
       it("should execute 'file-available' event on event handler when message status is CURRENT", () => {
         const message = {
           "topic": "file-update",
-          "filePath": "test.png",
+          "filePath": "test file.png",
+          "cacheKey": "test%20file.png",
           "status": "current"
         };
 
-        riseContentSentinel.watchFiles("test.png");
+        riseContentSentinel.watchFiles("test file.png");
+        riseContentSentinel._handleMessage(message);
+        expect(eventHandler).toHaveBeenCalledWith({
+          event: "file-available",
+          filePath: message.filePath,
+          fileUrl: `${origin}/${message.cacheKey}`
+        });
+      });
+
+      it("should use filePath to form the fileUrl if cacheKey is imissing", () => {
+        const message = {
+          "topic": "file-update",
+          "filePath": "test file.png",
+          "status": "current"
+        };
+
+        riseContentSentinel.watchFiles("test file.png");
         riseContentSentinel._handleMessage(message);
         expect(eventHandler).toHaveBeenCalledWith({
           event: "file-available",

--- a/test/unit/rise-content-sentinel.test.js
+++ b/test/unit/rise-content-sentinel.test.js
@@ -80,7 +80,7 @@ describe("RiseContentSentinel", () => {
         });
       });
 
-      it("should use filePath to form the fileUrl if cacheKey is imissing", () => {
+      it("should use filePath to form the fileUrl if cacheKey is missing", () => {
         const message = {
           "topic": "file-update",
           "filePath": "test file.png",

--- a/test/unit/rise-content-sentinel.test.js
+++ b/test/unit/rise-content-sentinel.test.js
@@ -67,7 +67,7 @@ describe("RiseContentSentinel", () => {
         const message = {
           "topic": "file-update",
           "filePath": "test file.png",
-          "cachePath": "test%20file.png",
+          "cachePath": "/test%20file.png",
           "status": "current"
         };
 
@@ -76,7 +76,7 @@ describe("RiseContentSentinel", () => {
         expect(eventHandler).toHaveBeenCalledWith({
           event: "file-available",
           filePath: message.filePath,
-          fileUrl: `${origin}/${message.cachePath}`
+          fileUrl: `${origin}${message.cachePath}`
         });
       });
 

--- a/test/unit/rise-content-sentinel.test.js
+++ b/test/unit/rise-content-sentinel.test.js
@@ -67,7 +67,7 @@ describe("RiseContentSentinel", () => {
         const message = {
           "topic": "file-update",
           "filePath": "test file.png",
-          "cacheKey": "test%20file.png",
+          "cachePath": "test%20file.png",
           "status": "current"
         };
 
@@ -76,11 +76,11 @@ describe("RiseContentSentinel", () => {
         expect(eventHandler).toHaveBeenCalledWith({
           event: "file-available",
           filePath: message.filePath,
-          fileUrl: `${origin}/${message.cacheKey}`
+          fileUrl: `${origin}/${message.cachePath}`
         });
       });
 
-      it("should use filePath to form the fileUrl if cacheKey is missing", () => {
+      it("should use filePath to form the fileUrl if cachePath is missing", () => {
         const message = {
           "topic": "file-update",
           "filePath": "test file.png",


### PR DESCRIPTION
## Description
Add `cacheKey` to Content Sentinel file update notification

## Motivation and Context
Fix for https://github.com/Rise-Vision/content-sentinel/issues/124

## How Has This Been Tested?
- Added unit test
- Tested with widget-image and widget-video using proxy. Used viewer-stage-1 to test the fix in the Content Sentinel that includes `cacheKey`. Used viewer-stage-2 to test backwards compatibility i.e. `cacheKey` field is missing.

## Release Plan:
- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
If any Release Checklist items were intentionally skipped, please provide which ones and the reasons why
