### PR TITLE
Fix/issue 137

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "common-component",
-  "version": "1.19.0",
+  "version": "1.19.1",
   "description": "Common code for new rise components",
   "main": "index.js",
   "scripts": {

--- a/rise-content-sentinel.js
+++ b/rise-content-sentinel.js
@@ -160,7 +160,7 @@ export default class RiseContentSentinel {
     while (win.parent && win.parent !== win) {
       win = win.parent;
 
-      if ( win.RiseVision && win.RiseVision.Viewer ) {
+      if ( win.contentSentinelInitializer === true ) {
         found = win;
       }
     }

--- a/rise-content-sentinel.js
+++ b/rise-content-sentinel.js
@@ -159,7 +159,7 @@ export default class RiseContentSentinel {
     while (win.parent && win.parent !== win) {
       win = win.parent;
 
-      if ( win.contentSentinelInitializer === true ) {
+      if (win.contentSentinelInitializer) {
         break;
       }
     }

--- a/rise-content-sentinel.js
+++ b/rise-content-sentinel.js
@@ -155,17 +155,16 @@ export default class RiseContentSentinel {
 
   _getTopLevelViewerWindow() {
     let win = window;
-    let found = win;
 
     while (win.parent && win.parent !== win) {
       win = win.parent;
 
       if ( win.contentSentinelInitializer === true ) {
-        found = win;
+        break;
       }
     }
 
-    return found;
+    return win;
   }
 
   _send(message) {

--- a/rise-content-sentinel.js
+++ b/rise-content-sentinel.js
@@ -153,18 +153,19 @@ export default class RiseContentSentinel {
     }
   }
 
-  _getViewerWindow() {
+  _getTopLevelViewerWindow() {
     let win = window;
+    let found = win;
 
     while (win.parent && win.parent !== win) {
       win = win.parent;
 
       if ( win.RiseVision && win.RiseVision.Viewer ) {
-        break;
+        found = win;
       }
     }
 
-    return win;
+    return found;
   }
 
   _send(message) {
@@ -176,7 +177,7 @@ export default class RiseContentSentinel {
       this._getHttpParameter( "frameElementId" ) :
       window.frameElement ? window.frameElement.id : "";
 
-    const viewerWindow = this._getViewerWindow();
+    const viewerWindow = this._getTopLevelViewerWindow();
 
     message.topic = "watch";
     message.frameElementId = frameElementId;

--- a/test/unit/rise-content-sentinel.test.js
+++ b/test/unit/rise-content-sentinel.test.js
@@ -569,4 +569,49 @@ describe("RiseContentSentinel", () => {
     });
   });
 
+  describe("_getTopLevelViewerWindow()", () => {
+    let windowSpy;
+
+    beforeEach(() => {
+      windowSpy = jest.spyOn(window, "window", "get");
+    });
+
+    afterEach(() => {
+      windowSpy.mockRestore();
+    });
+
+    it("should find the top level viewer window", () => {
+      const viewer = {
+        contentSentinelInitializer: true,
+        parent: {}
+      };
+      windowSpy.mockImplementation(() => ({
+        parent: {
+          parent: {
+            parent: viewer
+          }
+        }
+      }));
+
+      const top = riseContentSentinel._getTopLevelViewerWindow();
+
+      expect(top).toEqual(viewer);
+    });
+
+    it("should return top level if flag was not found", () => {
+      const viewer = {};
+      windowSpy.mockImplementation(() => ({
+        parent: {
+          parent: {
+            parent: viewer
+          }
+        }
+      }));
+
+      const top = riseContentSentinel._getTopLevelViewerWindow();
+
+      expect(top).toEqual(viewer);
+    });
+  });
+
 });


### PR DESCRIPTION
## Description
Change viewer lookup algorighm so it's based on contentSentinelInitializer flag.

## Motivation and Context
Part of fix for issue 137 as described here: https://docs.google.com/document/d/1qPJQeh1J5KsdH6rw7o8BYTy3JNarg1jDtvwooNV32rA/edit#

## How Has This Been Tested?
Tested with current nested widget-image here: https://apps.risevision.com/schedules/details/43cc8c2a-ffc7-47ab-a2c5-5efa40b1ee86?cid=7fa5ee92-7deb-450b-a8d5-e5ed648c575f
The presentation points to a staged widget-image version: https://apps.risevision.com/editor/workspace/525675fc-f86a-4c23-b7f9-a3851762d7aa/htmleditor?cid=7fa5ee92-7deb-450b-a8d5-e5ed648c575f

I also tested the presentation directly ( not nested ).

Also, this will still behave as currently as the nested viewer has still no being removed.

## Release Plan:
To be released before Friday. This doesn't affect runtime behavior until this version is merged with a component.

- As the Submitter, upon requesting review of this pull request, I confirm that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed. 
- As the Reviewer, upon approving the changes in this PR, I confirm I have reviewed and I agree that the [Release Checklist](https://help.risevision.com/hc/en-us/articles/360031119991) has been completed

#### Release Checklist Items Skipped?
No
